### PR TITLE
Partial implementation of unused vars

### DIFF
--- a/sampleProxy/24Solver/apiproxy/proxies/default.xml
+++ b/sampleProxy/24Solver/apiproxy/proxies/default.xml
@@ -16,7 +16,7 @@
             <Step>
                 <FaultRules/>
                 <Name>ExtractPayloadVariables</Name>
-                <Condition>request.verb="POST" and request.header.contenttype="application/json"</Condition>
+                <Condition>{wackyvar.foo} and request.verb="POST" and request.header.contenttype="application/json" or {foovar}</Condition>
             </Step>
             <Step>
             </Step>

--- a/src/package/Endpoint.js
+++ b/src/package/Endpoint.js
@@ -154,7 +154,7 @@ Endpoint.prototype.warn = function(msg) {
 };
 
 Endpoint.prototype.err = function(msg) {
-    this.parent.err.push(msg);
+    this.parent.err(msg);
 };
 
 Endpoint.prototype.summarize = function() {

--- a/src/package/plugins/unusedVariables.js
+++ b/src/package/plugins/unusedVariables.js
@@ -4,6 +4,10 @@ var name="Unused variables",
 // This plugin does **NOT** check for variables that are used incorrectly.
 // TODO: FaultRules
 
+// basic regex for finding variables
+// TODO: handle objects -- right now just verify the highest level variable.
+var varFinder = /{([^}\.]+?)(\.[^}]+?)??}/g;
+
 // preload the symbol table with framework globals
 var symtab = {
 	"proxy":[ "Edge Global" ],
@@ -17,12 +21,53 @@ var errors = [];
 // warnings that will be reported at the end of the process
 var warnings = [];
 
-function checkBundle(bundle) {
-
+// Process proxyendpoints in the following order:
+// 1. preflow - request [steps]
+// 2. flow - request [steps]
+// 3. postflow - request [steps]
+// 4. routerules
+//    - targetendpoint
+//       . pre/flow/post
+//       . pre - response
+//       . flow - response
+//       . post - response
+// TODO: inspect things referenced by steps to populate symbol table and check for bad var references.
+var onBundle = function (bundle) {
+	bundle.getProxyEndpoints().forEach(function(endpoint){
+		endpoint.getPreFlow().getFlowRequest().getSteps().forEach( function(step) {
+			if( step.getName()) {
+				var badVars = getUndefinedVariables(step.getName());
+				badVars.forEach(function(badvar){
+					step.err("Variable {" + badvar + "} was used in step name, but not previously defined");
+				});
+			} else {
+				step.warn("Step in preFlow does not seem to call anything (empty <Name> node)");
+			}
+			if( step.getCondition()) {
+				var badVars = getUndefinedVariables(step.getCondition().getExpression());
+				badVars.forEach(function(badvar){
+					step.err("Variable {" + badvar + "} was used in step condition, but not previously defined");
+				});
+			}
+		});
+	});
 }
 
-module.exports {
+// return a list of variables referenced in this string 
+// that are undefined (may be empty)
+var getUndefinedVariables = function (value) {
+	var undefinedVars = [];
+	while((match = varFinder.exec(value)) != null) {
+		var variable = match[1];
+		if( ! (variable in symtab)) {
+			undefinedVars.push(variable)
+		}
+	}
+	return undefinedVars;
+}
+
+module.exports = {
 	name,
 	description,
-	checkBundle
+	onBundle
 };

--- a/src/package/plugins/unusedVariables.js
+++ b/src/package/plugins/unusedVariables.js
@@ -43,6 +43,8 @@ var onBundle = function (bundle) {
 		});
 		evaluateSteps(endpoint.getPostFlow().getFlowRequest().getSteps(), localSymtab);
 
+		// TODO: evalute routrule conditions
+
 		var intermediateSymtab = localSymtab.slice(0); // don't update orig array references!
 		var intermediateUsage = JSON.parse(JSON.stringify(usageMetrics)); // save usage metrics
 		// iterate through routerules now ...
@@ -72,7 +74,6 @@ var onBundle = function (bundle) {
 			});
 			evaluateSteps(endpoint.getPostFlow().getFlowResponse().getSteps(), localSymtab);
 
-			// TODO: report on variables defined but not used in this target flow
 			localSymtab.forEach(function(symbol){
 				if( !usageMetrics[symbol]) {
 					target.warn("Target flow defines but does not use symbol " + symbol);

--- a/src/package/plugins/unusedVariables.js
+++ b/src/package/plugins/unusedVariables.js
@@ -1,0 +1,28 @@
+var name="Unused variables",
+	description="Look for variables that were defined but not referenced";
+
+// This plugin does **NOT** check for variables that are used incorrectly.
+// TODO: FaultRules
+
+// preload the symbol table with framework globals
+var symtab = {
+	"proxy":[ "Edge Global" ],
+	"request": [ "Edge Global" ],
+	"response": [ "Edge Global" ]
+};
+
+// errors that will be reported at the end of the process
+var errors = [];
+
+// warnings that will be reported at the end of the process
+var warnings = [];
+
+function checkBundle(bundle) {
+
+}
+
+module.exports {
+	name,
+	description,
+	checkBundle
+};


### PR DESCRIPTION
Can detect variables not used in flow steps; build symbol table from parts of flow including extractvariables (json and xml payload only at the moment).

TODO: 

1. parse javascript and determine what vars are used/set inside JS
2. other kinds of extract variables (e.g. query params etc)
