### PR TITLE
hotfix: correctly return all endpoints.

### DIFF
--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -580,7 +580,7 @@ Bundle.prototype.getTargetEndpoints = function() {
 Bundle.prototype.getEndpoints = function() {
   if (!this.endpoints) {
     this.endpoints = this.getProxyEndpoints();
-    this.endpoints.concat(this.getTargetEndpoints());
+    this.endpoints = this.endpoints.concat(this.getTargetEndpoints());
   }
   return this.endpoints;
 };


### PR DESCRIPTION
The Bundle.prototype.getEndpoints method uses Array.concat(), but does not assign the result.

Array.concat() does not affect the Array it is invoked on, but instead returns a new array. [See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat]

By assigning the result to the appropriate variable, target endpoints are returned in addition to the proxy endpoints.