### PR TITLE
hotfix: correct warning/error counts

### DIFF
--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -331,7 +331,7 @@ Bundle.prototype.addMessage = function(msg) {
       this.report.warningCount++;
       break;
     case 2:
-      this.report.warningCount++;
+      this.report.errorCount++;
       break;
   }
 };

--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -406,7 +406,7 @@ Endpoint.prototype.addMessage = function(msg) {
       this.report.warningCount++;
       break;
     case 2:
-      this.report.warningCount++;
+      this.report.errorCount++;
       break;
   }
 };

--- a/lib/package/Policy.js
+++ b/lib/package/Policy.js
@@ -154,7 +154,7 @@ Policy.prototype.addMessage = function(msg) {
       this.report.warningCount++;
       break;
     case 2:
-      this.report.warningCount++;
+      this.report.errorCount++;
       break;
   }
 };

--- a/lib/package/Resource.js
+++ b/lib/package/Resource.js
@@ -58,7 +58,7 @@ Resource.prototype.addMessage = function(msg) {
       this.report.warningCount++;
       break;
     case 2:
-      this.report.warningCount++;
+      this.report.errorCount++;
       break;
   }
 };


### PR DESCRIPTION
Currently, errors and warnings only increment the warningCount.

This corrects that and increments the appropriate property.