### PR TITLE
Fix issue where manifests folder not recognized as valid

### DIFF
--- a/lib/package/plugins/checkBundleStructure.js
+++ b/lib/package/plugins/checkBundleStructure.js
@@ -143,6 +143,7 @@ var bundleStructure = {
     name: "apiproxy",
     files: { extensions: ["xml", "md"], maxCount: 1 },
     folders: [
+	  { name: "manifests", required: false, files: { extensions: ["xml"] } },
       { name: "policies", required: false, files: { extensions: ["xml"] } },
       {
         name: "stepdefinitions",


### PR DESCRIPTION
Fixing bug: #108 