### PR TITLE
Fix #135: wsdl folder is not recognized by plugin BN001

### DIFF
--- a/lib/package/plugins/checkBundleStructure.js
+++ b/lib/package/plugins/checkBundleStructure.js
@@ -242,6 +242,13 @@ var bundleStructure = {
               extensions: ["js", "json", "yaml", "ejs"]
             },
             folders: { any: true }
+          },
+          {
+            name: "wsdl",
+            required: false,
+            files: {
+              extensions: ["wsdl"]
+            }
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apigeelint",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Node module to lint and Apigee Edge bundle.",
   "main": "function.js",
   "bin": {


### PR DESCRIPTION
Added `wsdl ` folder to the valid bundle structure

Fix #136 